### PR TITLE
chore: switch from aesonDrop to aesonPrefix function

### DIFF
--- a/server/src/Birdism/Api.hs
+++ b/server/src/Birdism/Api.hs
@@ -21,7 +21,7 @@ import qualified Data.Text         as T
 newtype ApiResponse a
   = ApiResponse { _arpResult :: a }
   deriving (Show, Eq)
-$(J.deriveJSON (J.aesonDrop 4 J.snakeCase) ''ApiResponse)
+$(J.deriveJSON (J.aesonPrefix J.snakeCase) ''ApiResponse)
 
 
 data SearchRequest
@@ -30,7 +30,7 @@ data SearchRequest
   , _srqFamily :: !ScientificName
   -- ^ 'ScientificName' of the family
   } deriving (Show, Eq)
-$(J.deriveJSON (J.aesonDrop 4 J.snakeCase) ''SearchRequest)
+$(J.deriveJSON (J.aesonPrefix J.snakeCase) ''SearchRequest)
 
 processSearch
   :: ( MonadIO m
@@ -71,14 +71,14 @@ newtype GetFamilyScientificNameRequest
   deriving (Show, Eq, Generic)
 
 instance J.FromJSON GetFamilyScientificNameRequest where
-  parseJSON = J.genericParseJSON (J.aesonDrop (T.length "_gfsnr") J.snakeCase)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 newtype GetFamilyScientificNameResponse
   = GetFamilyScientificNameResponse { _gfsnrFamilies :: [Family] }
   deriving (Show, Eq, Generic)
 
 instance J.ToJSON GetFamilyScientificNameResponse where
-  toJSON = J.genericToJSON (J.aesonDrop (T.length "_gfsnr") J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 getFamilyScientificName
   :: ( MonadIO m

--- a/server/src/Birdism/Config.hs
+++ b/server/src/Birdism/Config.hs
@@ -44,12 +44,11 @@ data EBirdConf
 
 makeClassy ''EBirdConf
 
--- $(J.deriveJSON (J.aesonDrop 4 J.snakeCase) ''EBirdConf)
 instance J.ToJSON EBirdConf where
-  toJSON = J.genericToJSON (J.aesonDrop 4 J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 instance J.FromJSON EBirdConf where
-  parseJSON = J.genericParseJSON (J.aesonDrop 4 J.snakeCase)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 data FlickrConf
   = FlickrConf
@@ -58,12 +57,10 @@ data FlickrConf
   } deriving (Show, Eq, Generic)
 
 instance J.ToJSON FlickrConf where
-  toJSON = J.genericToJSON (J.aesonDrop 3 J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 instance J.FromJSON FlickrConf where
-  parseJSON = J.genericParseJSON (J.aesonDrop 3 J.snakeCase)
-
--- $(J.deriveJSON (J.aesonDrop 3 J.snakeCase) ''FlickrConf)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 makeClassy ''FlickrConf
 
@@ -77,12 +74,10 @@ data AppConfig
   } deriving (Show, Eq, Generic)
 
 instance J.ToJSON AppConfig where
-  toJSON = J.genericToJSON (J.aesonDrop 2 J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 instance J.FromJSON AppConfig where
-  parseJSON = J.genericParseJSON (J.aesonDrop 2 J.snakeCase)
-
--- $(J.deriveJSON (J.aesonDrop 2 J.snakeCase) ''AppConfig)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 data DbConfig
   = DbConfig

--- a/server/src/Birdism/Lib.hs
+++ b/server/src/Birdism/Lib.hs
@@ -39,7 +39,7 @@ data SearchResultItem
   { _srrCommonName :: !CommonName
   , _srrImageUrls  :: ![ImgUrl]
   } deriving (Show, Eq)
-$(J.deriveJSON (J.aesonDrop 4 J.snakeCase) ''SearchResultItem)
+$(J.deriveJSON (J.aesonPrefix J.snakeCase) ''SearchResultItem)
 
 type SearchResult = [SearchResultItem]
 

--- a/server/src/Birdism/Types.hs
+++ b/server/src/Birdism/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings          #-}
 
 module Birdism.Types where
 
@@ -23,7 +22,7 @@ newtype ScientificName
 newtype CommonName
   = CommonName { uCommonName :: Text }
   deriving stock (Show, Eq, Generic)
-  deriving newtype ( Hashable, J.FromJSONKey, J.ToJSONKey, J.FromJSON, J.ToJSON, PG.ToField, PG.FromField)
+  deriving newtype (Hashable, J.FromJSONKey, J.ToJSONKey, J.FromJSON, J.ToJSON, PG.ToField, PG.FromField)
 
 newtype SpeciesCode
   = SpeciesCode { uSpeciesCode :: Text }
@@ -37,10 +36,10 @@ data Family
   } deriving (Show, Eq, Generic)
 
 instance J.ToJSON Family where
-  toJSON = J.genericToJSON (J.aesonDrop 2 J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 instance J.FromJSON Family where
-  parseJSON = J.genericParseJSON (J.aesonDrop 2 J.snakeCase)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 newtype RegionCode
   = RegionCode { uRegionCode :: Text }
@@ -64,10 +63,10 @@ data Bird
   } deriving (Show, Eq, Generic)
 
 instance J.ToJSON Bird where
-  toJSON = J.genericToJSON (J.aesonDrop 1 J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 instance J.FromJSON Bird where
-  parseJSON = J.genericParseJSON (J.aesonDrop 1 J.snakeCase)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 makeBird :: SpeciesCode -> CommonName -> ScientificName -> Family -> Bird
 makeBird spCode comName sciName family =
@@ -81,10 +80,10 @@ data Region
   } deriving (Show, Eq, Generic)
 
 instance J.ToJSON Region where
-  toJSON = J.genericToJSON (J.aesonDrop 2 J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 instance J.FromJSON Region where
-  parseJSON = J.genericParseJSON (J.aesonDrop 2 J.snakeCase)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 data Checklist
   = Checklist

--- a/server/src/Service/Ebird/V2/Data/Observation.hs
+++ b/server/src/Service/Ebird/V2/Data/Observation.hs
@@ -27,10 +27,10 @@ data ChecklistObservation
   } deriving (Show, Eq, Generic)
 
 instance J.ToJSON ChecklistObservation where
-  toJSON = J.genericToJSON (J.aesonDrop 3 J.snakeCase)
+  toJSON = J.genericToJSON (J.aesonPrefix J.snakeCase)
 
 instance J.FromJSON ChecklistObservation where
-  parseJSON = J.genericParseJSON (J.aesonDrop 3 J.snakeCase)
+  parseJSON = J.genericParseJSON (J.aesonPrefix J.snakeCase)
 
 searchCheckLists
   :: ( MonadReader r m

--- a/server/src/Service/Ebird/V2/Ref/Region.hs
+++ b/server/src/Service/Ebird/V2/Ref/Region.hs
@@ -39,7 +39,7 @@ data RRegion a
   , _rName :: !Text
   } deriving (Show, Eq)
 
-$(J.deriveJSON (J.aesonDrop 2 J.snakeCase) ''RRegion)
+$(J.deriveJSON (J.aesonPrefix J.snakeCase) ''RRegion)
 
 data SubRegion
   = SubRegion
@@ -47,7 +47,7 @@ data SubRegion
   , _srName :: !Text
   } deriving (Show, Eq)
 
-$(J.deriveJSON (J.aesonDrop 3 J.snakeCase) ''SubRegion)
+$(J.deriveJSON (J.aesonPrefix J.snakeCase) ''SubRegion)
 
 newtype SubRegions
   = SubRegions { unSubRegions :: [RRegion Subnational2] }

--- a/server/src/Service/Flickr/Photos.hs
+++ b/server/src/Service/Flickr/Photos.hs
@@ -21,7 +21,7 @@ data FlickrPhotoResponse
   , _fprOwner  :: !Text
   } deriving (Show, Eq)
 
-$(J.deriveJSON (J.aesonDrop 4 J.snakeCase) ''FlickrPhotoResponse)
+$(J.deriveJSON (J.aesonPrefix J.snakeCase) ''FlickrPhotoResponse)
 
 newtype FlickrResponse
   = FlickrResponse { unFlickrResponse :: [FlickrPhotoResponse] }


### PR DESCRIPTION
Using `aesonPrefix` instead of `aesonDrop <number>`. `aesonPrefix` automatically drops characters till the first uppercase character.